### PR TITLE
eval: fix string literal bool evaluation

### DIFF
--- a/pkg/generator/operator/binary_test.go
+++ b/pkg/generator/operator/binary_test.go
@@ -432,3 +432,43 @@ func TestBinaryCaseString_3(t *testing.T) {
 	assert.NoError(t, err, "should not return error")
 	assert.Equal(t, util.CompareValue(actual, expected), true)
 }
+
+func TestNotString_1(t *testing.T) {
+	a := parser_driver.ValueExpr{}
+	a.SetValue("Sss")
+	expected := parser_driver.ValueExpr{}
+	expected.SetValue(true)
+	actual, err := Not.Eval(a)
+	assert.NoError(t, err, "should not return error")
+	assert.Equal(t, util.CompareValue(actual, expected), true)
+
+	a.SetValue("12abc")
+	expected.SetValue(false)
+	actual, err = Not.Eval(a)
+	assert.NoError(t, err, "should not return error")
+	assert.Equal(t, util.CompareValue(actual, expected), true)
+
+	a.SetValue(".3,wZ!")
+	expected.SetValue(false)
+	actual, err = Not.Eval(a)
+	assert.NoError(t, err, "should not return error")
+	assert.Equal(t, util.CompareValue(actual, expected), true)
+
+	a.SetValue(".1")
+	expected.SetValue(false)
+	actual, err = Not.Eval(a)
+	assert.NoError(t, err, "should not return error")
+	assert.Equal(t, util.CompareValue(actual, expected), true)
+
+	a.SetValue(".0000001e+00")
+	expected.SetValue(false)
+	actual, err = Not.Eval(a)
+	assert.NoError(t, err, "should not return error")
+	assert.Equal(t, util.CompareValue(actual, expected), true)
+
+	a.SetValue(".000000e+00")
+	expected.SetValue(true)
+	actual, err = Not.Eval(a)
+	assert.NoError(t, err, "should not return error")
+	assert.Equal(t, util.CompareValue(actual, expected), true)
+}

--- a/pkg/util/generator.go
+++ b/pkg/util/generator.go
@@ -43,11 +43,17 @@ func ConvertToBoolOrNull(a parser_driver.ValueExpr) int8 {
 		return 1
 	case tidb_types.KindString:
 		s := a.GetValue().(string)
-		match, _ := regexp.MatchString(`^[\-\+]?[1-9]+|^[\+\-]?0+[1-9]`, s)
-		if match {
-			return 1
+		re, _ := regexp.Compile(`^[-+]?[0-9]*\.?[0-9]+`)
+		matchall := re.FindAllString(s, -1)
+		if len(matchall) == 0 {
+			return 0
 		}
-		return 0
+		numStr := matchall[0]
+		match, _ := regexp.MatchString(`^[-+]?0*\.?0+$`, numStr)
+		if match {
+			return 0
+		}
+		return 1
 	case tidb_types.KindMysqlDecimal:
 		d := a.GetMysqlDecimal()
 		if d.IsZero() {


### PR DESCRIPTION
For sql below, when we eval (!".07QA#aLv"), we should get 0

```SQL
SELECT table_int_float.id_3,table_int_float.col_int_3,table_int_float.col_float_3 FROM table_int_float WHERE ((!table_int_float.col_float_3) OR (!".07QA#aLv"))
table_int_float.col_float_3=0.5 is FLOAT type
table_int_float.col_int_3=1 is INT type
table_int_float.id_3=8 is INT type
```