### PR TITLE
TPL: don't make aggregate function be embedded in select expressions

### DIFF
--- a/pkg/sqlancer/sqlancer.go
+++ b/pkg/sqlancer/sqlancer.go
@@ -329,10 +329,9 @@ func (p *SQLancer) progress() {
 		var transformers []transformer.Transformer
 		if approach == approachNoREC {
 			transformers = []transformer.Transformer{transformer.NoREC}
-		} else {
+		}
+		if approach == approachTLP {
 			transformers = []transformer.Transformer{
-				// approachTLP contains transformer.NoREC
-				transformer.NoREC,
 				&transformer.TLPTrans{
 					Expr: &ast.ParenthesesExpr{Expr: p.ConditionClause(genCtx, 2)},
 					Tp:   transformer.RandTLPType(),


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

TLP cannot process the case when the aggregate-function is embedded in select expressions, and NoREC transformer builds IFNULL(sum(c), 0) ... form SQL which is the only source of mixing aggregate function in select expressions.

So this PR removes the `transformer.NoREC` when selecting TLP approach.